### PR TITLE
Update README for Docker Compose syntax and license change

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Quick start:
 ```bash
 cp .env.example .env
 # Edit .env with your configuration
-docker-compose up -d
+docker compose up -d
 ```
 
 The application uses Docker Compose with three services:
@@ -219,7 +219,7 @@ Requirements:
 
 ## License
 
-MIT
+GNU AGPL v3
 
 ## Contributing
 


### PR DESCRIPTION
Revise the README to reflect the updated Docker Compose syntax and change the license to GNU AGPL v3.